### PR TITLE
Update ExportWriterPdf.php

### DIFF
--- a/src/ExportWriterPdf.php
+++ b/src/ExportWriterPdf.php
@@ -32,7 +32,7 @@ class ExportWriterPdf extends Mpdf
     /**
      * @inheritdoc
      */
-    protected function createExternalWriterInstance($config = [])
+    protected function createExternalWriterInstance(array $config) : \Mpdf\Mpdf
     {
         if (isset($config['tempDir'])) {
             unset($config['tempDir']);


### PR DESCRIPTION
fixed:  PHP Compile Error – yii\base\ErrorException
Declaration of kartik\export\ExportWriterPdf::createExternalWriterInstance($config = []) must be compatible with PhpOffice\PhpSpreadsheet\Writer\Pdf\Mpdf::createExternalWriterInstance(array $config): Mpdf\Mpdf

Test in PHP 8,1

## Scope
This pull request includes a

- [x ] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-export/blob/master/CHANGE.md)):

-
-
-

## Related Issues
If this is related to an existing ticket, include a link to it as well.